### PR TITLE
Fix gmsh version retrieval

### DIFF
--- a/gmsh_interop/reader.py
+++ b/gmsh_interop/reader.py
@@ -26,8 +26,9 @@ THE SOFTWARE.
 import numpy as np
 
 from pytools import memoize_method
+
 from gmsh_interop.runner import (  # noqa: F401
-        ScriptSource, LiteralSource, FileSource, ScriptWithFilesSource)
+    FileSource, LiteralSource, ScriptSource, ScriptWithFilesSource)
 
 
 __doc__ = """
@@ -102,8 +103,7 @@ def generate_triangle_volume_tuples(order):
 
 
 def generate_quad_vertex_tuples(dim, order):
-    from pytools import \
-            generate_nonnegative_integer_tuples_below
+    from pytools import generate_nonnegative_integer_tuples_below
     for tup in generate_nonnegative_integer_tuples_below(2, dim):
         yield tuple(order * i for i in tup)
 
@@ -194,16 +194,16 @@ class GmshSimplexElementBase(GmshElementBase):
     def node_count(self):
         """Return the number of interpolation nodes in this element."""
         import math
-        from operator import mul
         from functools import reduce
+        from operator import mul
         return (
                 reduce(mul, (self.order + 1 + i for i in range(self.dimensions)), 1)
                 // math.factorial(self.dimensions))
 
     @memoize_method
     def lexicographic_node_tuples(self):
-        from pytools import \
-                generate_nonnegative_integer_tuples_summing_to_at_most as gnitstam
+        from pytools import (
+            generate_nonnegative_integer_tuples_summing_to_at_most as gnitstam)
         result = list(gnitstam(self.order, self.dimensions))
 
         assert len(result) == self.node_count()

--- a/gmsh_interop/runner.py
+++ b/gmsh_interop/runner.py
@@ -24,13 +24,15 @@ THE SOFTWARE.
 """
 
 try:
-    from packaging.version import parse as LooseVersion     # noqa: N812
+    from packaging.version import parse as LooseVersion  # noqa: N812
 except ImportError:
     from distutils.version import LooseVersion
 
+import logging
+
 from pytools import memoize_method
 
-import logging
+
 logger = logging.getLogger(__name__)
 
 
@@ -51,7 +53,7 @@ class GmshError(RuntimeError):
 # {{{ tools
 
 def _erase_dir(dir):
-    from os import listdir, unlink, rmdir
+    from os import listdir, rmdir, unlink
     from os.path import join
     for name in listdir(dir):
         unlink(join(dir, name))
@@ -188,7 +190,7 @@ class GmshRunner:
         temp_dir_mgr = _TempDirManager()
         try:
             working_dir = temp_dir_mgr.path
-            from os.path import join, abspath, exists
+            from os.path import abspath, exists, join
 
             if isinstance(self.source, ScriptSource):
                 source_file_name = join(
@@ -300,8 +302,8 @@ class GmshRunner:
             self.output_file = open(output_file_name)
 
             if self.save_tmp_files_in:
-                import shutil
                 import errno
+                import shutil
                 try:
                     shutil.copytree(working_dir, self.save_tmp_files_in)
                 except FileExistsError:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,13 +1,20 @@
 [flake8]
 ignore = E126,E127,E128,E123,E226,E241,E242,E265,E402,W503
 max-line-length=85
-exclude=pytools/arithmetic_container.py,pytools/decorator.py
 
 inline-quotes = "
 docstring-quotes = """
 multiline-quotes = """
 
 # enable-flake8-bugbear
+
+[isort]
+known_firstparty=pytools
+known_local_folder=gmsh_interop
+line_length = 85
+lines_after_imports = 2
+combine_as_imports = True
+multi_line_output = 4
 
 [wheel]
 universal = 1

--- a/test/test_gmsh.py
+++ b/test/test_gmsh.py
@@ -29,8 +29,8 @@ def search_on_path(filenames):
     """Find file on system path."""
     # http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/52224
 
-    from os.path import exists, abspath, join
-    from os import pathsep, environ
+    from os import environ, pathsep
+    from os.path import abspath, exists, join
 
     search_path = environ["PATH"]
 
@@ -110,7 +110,7 @@ def test_simplex_gmsh(dim, order, visualize=False):
     else:
         save_tmp_files_in = None
 
-    from gmsh_interop.reader import generate_gmsh, GmshMeshReceiverBase
+    from gmsh_interop.reader import GmshMeshReceiverBase, generate_gmsh
     from gmsh_interop.runner import ScriptSource
 
     mr = GmshMeshReceiverBase()
@@ -130,7 +130,7 @@ def test_quad_gmsh(dim, order, visualize=False):
     else:
         save_tmp_files_in = None
 
-    from gmsh_interop.reader import generate_gmsh, GmshMeshReceiverBase
+    from gmsh_interop.reader import GmshMeshReceiverBase, generate_gmsh
     from gmsh_interop.runner import ScriptSource
 
     if dim == 2:


### PR DESCRIPTION
Just tried running this with version 4.11.1 and the heuristic that was in there (check stderr, else stdout) doesn't work anymore because stderr is not empty :cry:

This now looks at both, hopefully fixing the issue forever™.

P.S. Also ran `isort` because it seems fairly unintrusive.