### PR TITLE
Pin version 3.10 for pyright

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -36,6 +36,14 @@
             {
                 "code": "reportUnknownMemberType",
                 "range": {
+                    "startColumn": 12,
+                    "endColumn": 25,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnknownMemberType",
+                "range": {
                     "startColumn": 4,
                     "endColumn": 19,
                     "lineCount": 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,12 @@ known-local-folder = ["gmsh_interop"]
 lines-after-imports = 2
 
 [tool.basedpyright]
+pythonVersion = "3.10"
+pythonPlatform = "All"
+
 reportImplicitStringConcatenation = "none"
 reportUnnecessaryIsInstance = "none"
 reportUnusedCallResult = "none"
 reportAny = "none"
+
+exclude = [ "doc", ".env", ".conda-root" ]


### PR DESCRIPTION
Apparently that made a new warning: something about an `ndarray.reshape` having an unknown type (also somewhere in `gmsh-node-tuples.py`, so I left it alone).