### PR TITLE
Add option to save generated mesh file outside of temporary working dir

### DIFF
--- a/gmsh_interop/reader.py
+++ b/gmsh_interop/reader.py
@@ -596,6 +596,7 @@ def generate_gmsh(
         force_dimension: int | None = None,
         target_unit: Literal["M", "MM"] | None = None,
         output_file_name: str | None = None,
+        save_output_file_in: str | None = None,
         save_tmp_files_in: str | None = None) -> None:
     """Run gmsh and feed the output to *receiver*.
 
@@ -610,6 +611,7 @@ def generate_gmsh(
             gmsh_executable=gmsh_executable,
             target_unit=target_unit,
             output_file_name=output_file_name,
+            save_output_file_in=save_output_file_in,
             save_tmp_files_in=save_tmp_files_in)
 
     with runner:

--- a/gmsh_interop/runner.py
+++ b/gmsh_interop/runner.py
@@ -192,6 +192,15 @@ class GmshRunner:
             target_unit: Literal["M", "MM"] | None = None,
             save_output_file_in: str | None = None,
             save_tmp_files_in: str | None = None) -> None:
+        """
+        :arg output_file_name: the base name (including extension) of the output
+            mesh file.
+        :arg save_output_file_in: if specified, the output mesh file will be saved to
+            this directory.
+        :arg save_tmp_files_in: if specified, the temporary Gmsh files will be saved
+            to this directory.
+        """
+
         if isinstance(source, str):
             from warnings import warn
             warn("passing a string as 'source' is deprecated -- use "


### PR DESCRIPTION
Adds the option `save_output_file_in` to the gmsh runner to tell it to save the mesh file somewhere outside of the temporary working directory.